### PR TITLE
Fix textcolor based on average count for contrast

### DIFF
--- a/NVDVulnStatus.ipynb
+++ b/NVDVulnStatus.ipynb
@@ -243,7 +243,7 @@
     "df.index = df.index.strftime('%m/%d/%Y')\n",
     "df.index = pd.to_datetime(df.index, format='%m/%d/%Y')\n",
     "average_value = df.T.squeeze().mean()\n",
-    "textcolor_threshold = 200\n",
+    "textcolor_threshold = 100\n",
     "calculated_textcolor = 'White' if average_value > textcolor_threshold else 'Black'\n",
     "calplot.calplot(df.T.squeeze(), cmap='Blues', dropzero=True, edgecolor=\"Grey\", textcolor=calculated_textcolor, textformat='{:.0f}', textfiller='', suptitle='NVD CVEs Analyzed Per Day', figsize=(25,3));"
    ]

--- a/NVDVulnStatus.ipynb
+++ b/NVDVulnStatus.ipynb
@@ -242,7 +242,10 @@
     "df = df.to_frame()\n",
     "df.index = df.index.strftime('%m/%d/%Y')\n",
     "df.index = pd.to_datetime(df.index, format='%m/%d/%Y')\n",
-    "calplot.calplot(df.T.squeeze(), cmap='Blues', dropzero=True, edgecolor=\"Grey\", textcolor=\"Black\", textformat='{:.0f}', textfiller='', suptitle='NVD CVEs Analyzed Per Day', figsize=(25,3));"
+    "average_value = df.T.squeeze().mean()\n",
+    "textcolor_threshold = 200\n",
+    "calculated_textcolor = 'White' if average_value > textcolor_threshold else 'Black'\n",
+    "calplot.calplot(df.T.squeeze(), cmap='Blues', dropzero=True, edgecolor=\"Grey\", textcolor=calculated_textcolor, textformat='{:.0f}', textfiller='', suptitle='NVD CVEs Analyzed Per Day', figsize=(25,3));"
    ]
   },
   {
@@ -275,7 +278,10 @@
     "df = df.to_frame()\n",
     "df.index = df.index.strftime('%m/%d/%Y')\n",
     "df.index = pd.to_datetime(df.index, format='%m/%d/%Y')\n",
-    "calplot.calplot(df.T.squeeze(), cmap='Blues', dropzero=True, edgecolor=\"Grey\", textcolor=\"Black\", textformat='{:.0f}', textfiller='', suptitle='NVD CVEs Published Per Day', figsize=(25,3));"
+    "average_value = df.T.squeeze().mean()\n",
+    "textcolor_threshold = 750\n",
+    "calculated_textcolor = 'White' if average_value > textcolor_threshold else 'Black'\n",
+    "calplot.calplot(df.T.squeeze(), cmap='Blues', dropzero=True, edgecolor=\"Grey\", textcolor=calculated_textcolor, textformat='{:.0f}', textfiller='', suptitle='NVD CVEs Published Per Day', figsize=(25,3));"
    ]
   },
   {


### PR DESCRIPTION
I'm not super sure how to test this, since I've never written a Jupyter notebook before, but I think this will color the text white against the very dark blue colors of very high, outlier values. This will need to be adjusted, probably, if some new stupendously high value hits the data set.

The problem I'm trying to solve is the black-on-dark-blue coloring seen here:

<img width="400" alt="image" src="https://github.com/jgamblin/NVDAnalysisStatus/assets/24144/ff6af8ef-1ad5-4985-9471-0b0fed9710eb">
